### PR TITLE
Adds the rpm spec file in the source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ include etc/gridmon.errdb
 include etc/gridmon.conf
 include etc/nagios-submit.conf
 include CHANGES
+include python-GridMon.spec


### PR DESCRIPTION
The ARGO RPM Builder expects to find the SPEC file in the source
distribution.
